### PR TITLE
Add Consumer interface

### DIFF
--- a/cmd/vessel/main.go
+++ b/cmd/vessel/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 
+	"github.com/foohq/vessel/internal/consumer"
 	"github.com/foohq/vessel/internal/dialer"
 	"github.com/foohq/vessel/internal/log"
 	"github.com/foohq/vessel/internal/vessel"
@@ -50,12 +51,6 @@ func main() {
 	}
 	defer conn.Conn().Close()
 
-	consumer, err := getConsumer(ctx, conn, Stream, Consumer)
-	if err != nil {
-		log.Debug("Cannot obtain durable consumer", "error", err)
-		return
-	}
-
 	store, err := getObjectStore(ctx, conn, ObjectStore)
 	if err != nil {
 		log.Debug("Cannot obtain object store", "error", err)
@@ -63,9 +58,13 @@ func main() {
 	}
 
 	err = vessel.New(vessel.Arguments{
-		ID:          AgentID,
-		Connection:  conn,
-		Consumer:    consumer,
+		ID:         AgentID,
+		Connection: conn,
+		Consumer: consumer.New(consumer.Arguments{
+			Connection: conn,
+			Stream:     Stream,
+			Consumer:   Consumer,
+		}),
 		ObjectStore: store,
 	}).Start(ctx)
 	if err != nil {
@@ -148,14 +147,6 @@ func decodeCertificateHandler(s string) func() (*x509.CertPool, error) {
 
 func getObjectStore(ctx context.Context, conn jetstream.JetStream, store string) (jetstream.ObjectStore, error) {
 	return conn.ObjectStore(ctx, store)
-}
-
-func getConsumer(ctx context.Context, conn jetstream.JetStream, stream, consumer string) (jetstream.Consumer, error) {
-	c, err := conn.Consumer(ctx, stream, consumer)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 func mustGetReconnectInterval() time.Duration {

--- a/internal/consumer/consumer_nats.go
+++ b/internal/consumer/consumer_nats.go
@@ -1,0 +1,86 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"iter"
+
+	proto "github.com/foohq/foojank-proto/go"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/foohq/vessel/internal/log"
+	"github.com/foohq/vessel/internal/vessel/message"
+)
+
+type Arguments struct {
+	Connection jetstream.JetStream
+	Stream     string
+	Consumer   string
+}
+
+type Consumer struct {
+	args Arguments
+}
+
+func New(args Arguments) *Consumer {
+	return &Consumer{
+		args: args,
+	}
+}
+
+func (s *Consumer) Messages(ctx context.Context) iter.Seq2[message.Msg, error] {
+	consumer, err := s.args.Connection.Consumer(ctx, s.args.Stream, s.args.Consumer)
+	if err != nil {
+		return func(yield func(message.Msg, error) bool) {
+			yield(nil, err)
+		}
+	}
+
+	return func(yield func(message.Msg, error) bool) {
+		for ctx.Err() == nil {
+			msg, err := consumer.Next(jetstream.FetchContext(ctx))
+			if err != nil {
+				if errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+					yield(nil, err)
+					return
+				}
+				continue
+			}
+
+			data, err := proto.Unmarshal(msg.Data())
+			if err != nil {
+				log.Debug("Cannot decode a message", "error", err)
+				_ = msg.Ack()
+				// Invalid messages are not propagated to a caller (do not call yield!).
+				continue
+			}
+
+			yield(Message{
+				msg:  msg,
+				data: data,
+			}, nil)
+		}
+	}
+}
+
+type Message struct {
+	msg  jetstream.Msg
+	data any
+}
+
+func (m Message) ID() string {
+	return m.msg.Headers().Get(nats.MsgIdHdr)
+}
+
+func (m Message) Subject() string {
+	return m.msg.Subject()
+}
+
+func (m Message) Data() any {
+	return m.data
+}
+
+func (m Message) Ack() error {
+	return m.msg.Ack()
+}

--- a/internal/vessel/service.go
+++ b/internal/vessel/service.go
@@ -3,6 +3,7 @@ package vessel
 import (
 	"context"
 	"errors"
+	"iter"
 	"os"
 	"os/user"
 	"runtime"
@@ -25,7 +26,7 @@ import (
 type Arguments struct {
 	ID          string
 	Connection  jetstream.JetStream
-	Consumer    jetstream.Consumer
+	Consumer    Consumer
 	ObjectStore jetstream.ObjectStore
 }
 
@@ -144,71 +145,26 @@ func (s *Service) Start(ctx context.Context) error {
 	return nil
 }
 
-var _ message.Msg = consumerMessage{}
-
-type consumerMessage struct {
-	msg  jetstream.Msg
-	data any
+type Consumer interface {
+	Messages(context.Context) iter.Seq2[message.Msg, error]
 }
 
-func (m consumerMessage) ID() string {
-	return m.msg.Headers().Get(nats.MsgIdHdr)
-}
-
-func (m consumerMessage) Subject() string {
-	return m.msg.Subject()
-}
-
-func (m consumerMessage) Data() any {
-	return m.data
-}
-
-func (m consumerMessage) Ack() error {
-	return m.msg.Ack()
-}
-
-func consumer(ctx context.Context, consumer jetstream.Consumer, outputCh chan message.Msg) error {
+func consumer(ctx context.Context, consumer Consumer, outputCh chan message.Msg) error {
 	log.Debug("Service started", "service", "vessel.consumer")
 	defer log.Debug("Service stopped", "service", "vessel.consumer")
 
-	msgs, err := consumer.Messages()
-	if err != nil {
-		log.Debug("Cannot obtain message context", "error", err)
-		return err
-	}
-
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			msg, err := msgs.Next()
-			if err != nil {
-				if errors.Is(err, jetstream.ErrMsgIteratorClosed) {
-					return
-				}
-				continue
-			}
-
-			data, err := proto.Unmarshal(msg.Data())
-			if err != nil {
-				log.Debug("Cannot decode a message", "error", err)
-				_ = msg.Ack()
-				continue
-			}
-
-			err = forwardMessage(outputCh, consumerMessage{
-				msg:  msg,
-				data: data,
-			})
-			if err != nil {
-				log.Debug("Cannot forward a message", "error", err)
-				continue
-			}
+	for msg, err := range consumer.Messages(ctx) {
+		if err != nil {
+			log.Debug("Cannot read a message", "error", err)
+			return err
 		}
-	})
 
-	<-ctx.Done()
-	msgs.Stop()
-	wg.Wait()
+		err = forwardMessage(outputCh, msg)
+		if err != nil {
+			log.Debug("Cannot forward a message", "error", err)
+			continue
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
The interface replaces jetstream.Consumer. This allows to decouple vessel from NATS module in the future.